### PR TITLE
[WIP] Expedition Sub-department

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -19,6 +19,7 @@
 	var/list/med = new()
 	var/list/sci = new()
 	var/list/car = new()
+	var/list/pla = new() //VOREStation Edit
 	var/list/civ = new()
 	var/list/bot = new()
 	var/list/misc = new()
@@ -72,6 +73,11 @@
 		if(real_rank in cargo_positions)
 			car[name] = rank
 			department = 1
+		//VOREStation Edit Begin
+		if(real_rank in planet_positions)
+			pla[name] = rank
+			department = 1
+		//VOREStation Edit End
 		if(real_rank in civilian_positions)
 			civ[name] = rank
 			department = 1
@@ -118,6 +124,13 @@
 		for(name in car)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[car[name]]</td><td>[isactive[name]]</td></tr>"
 			even = !even
+	//VOREStation Edit Begin
+	if(pla.len > 0)
+		dat += "<tr><th colspan=3>Exploration</th></tr>"
+		for(name in pla)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[pla[name]]</td><td>[isactive[name]]</td></tr>"
+			even = !even
+	//VOREStation Edit End
 	if(civ.len > 0)
 		dat += "<tr><th colspan=3>Civilian</th></tr>"
 		for(name in civ)

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -73,18 +73,15 @@ var/list/medical_positions = list(
 	"Geneticist",
 	"Psychiatrist",
 	"Chemist",
-	"Field Medic", // VOREStation Edit - Moved SAR from planetary -> medical
 	"Paramedic"
 )
 
 
 var/list/science_positions = list(
 	"Research Director",
-	"Pathfinder", // VOREStation Edit - Added Pathfinder
 	"Scientist",
 	"Geneticist",	//Part of both medical and science
 	"Roboticist",
-	"Explorer", // VOREStation Edit - Moved Explorer from planetary -> science
 	"Xenobiologist"
 )
 
@@ -104,7 +101,6 @@ var/list/civilian_positions = list(
 	"Librarian",
 	"Lawyer",
 	"Chaplain",
-	"Pilot",  // VOREStation Edit - Moved Pilot from planetary -> civ
 	USELESS_JOB, //VOREStation Edit - Visitor not Assistant
 	"Intern" //VOREStation Edit - Intern
 )
@@ -119,9 +115,10 @@ var/list/security_positions = list(
 
 
 var/list/planet_positions = list(
-	// "Explorer", // VOREStation Edit - Moved Explorer from planetary -> science
-	// "Pilot",  // VOREStation Edit - Moved Pilot from planetary -> civ
-	// "Search and Rescue"  // VOREStation Edit - Moved SAR from planetary -> medical
+	"Pathfinder", // VOREStation Edit - Added Pathfinder
+	"Explorer",
+	"Pilot",
+	"Field Medic"  // VOREStation Edit - Field Medic
 )
 
 

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -108,7 +108,7 @@
 				list("cat" = "Science", "jobs" = format_jobs(science_positions)),
 				list("cat" = "Security", "jobs" = format_jobs(security_positions)),
 				list("cat" = "Cargo", "jobs" = format_jobs(cargo_positions)),
-				list("cat" = "Planetside", "jobs" = format_jobs(planet_positions)),
+				list("cat" = "Exploration", "jobs" = format_jobs(planet_positions)), //VOREStation Edit
 				list("cat" = "Civilian", "jobs" = format_jobs(civilian_positions)),
 				list("cat" = "CentCom", "jobs" = format_jobs(get_all_centcom_jobs()))
 			)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -159,6 +159,7 @@ var/world_topic_spam_protect_time = world.timeofday
 				"med" = medical_positions,
 				"sci" = science_positions,
 				"car" = cargo_positions,
+				"pla" = planet_positions, //VOREStation Edit,
 				"civ" = civilian_positions,
 				"bot" = nonhuman_positions
 			)

--- a/code/global.dm
+++ b/code/global.dm
@@ -173,7 +173,7 @@ var/max_explosion_range = 14
 // Announcer intercom, because too much stuff creates an intercom for one message then hard del()s it.
 var/global/obj/item/device/radio/intercom/omni/global_announcer = new /obj/item/device/radio/intercom/omni(null)
 
-var/list/station_departments = list("Command", "Medical", "Engineering", "Science", "Security", "Cargo", "Civilian")
+var/list/station_departments = list("Command", "Medical", "Engineering", "Science", "Security", "Cargo", "Exploration", "Civilian") //VOREStation Edit
 
 //Icons for in-game HUD glasses. Why don't we just share these a little bit?
 var/static/icon/ingame_hud = icon('icons/mob/hud.dmi')

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -516,7 +516,28 @@
 				jobs += "</tr><tr align='center'>"
 				counter = 0
 		jobs += "</tr></table>"
+	//VOREStation Edit Start
+	//Exploration (Purple)
+		counter = 0
+		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
+		jobs += "<tr bgcolor='e79fff'><th colspan='[length(planet_positions)]'><a href='?src=\ref[src];jobban3=explorationdept;jobban4=\ref[M]'>Exploration Positions</a></th></tr><tr align='center'>"
+		for(var/jobPos in planet_positions)
+			if(!jobPos)	continue
+			var/datum/job/job = job_master.GetJob(jobPos)
+			if(!job) continue
 
+			if(jobban_isbanned(M, job.title))
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				counter++
+			else
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				counter++
+
+			if(counter >= 5) //So things dont get squiiiiished!
+				jobs += "</tr><tr align='center'>"
+				counter = 0
+		jobs += "</tr></table>"
+	//VOREstation Edit End
 	//Civilian (Grey)
 		counter = 0
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
@@ -670,6 +691,14 @@
 					var/datum/job/temp = job_master.GetJob(jobPos)
 					if(!temp) continue
 					joblist += temp.title
+			//VOREStation Edit Start
+			if("explorationdept")
+				for(var/jobPos in planet_positions)
+					if(!jobPos)	continue
+					var/datum/job/temp = job_master.GetJob(jobPos)
+					if(!temp) continue
+					joblist += temp.title
+			//VOREStation Edit End
 			if("civiliandept")
 				for(var/jobPos in civilian_positions)
 					if(!jobPos)	continue

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -54,7 +54,7 @@
 		if(alt_title && !(alt_title in job.alt_titles))
 			pref.player_alt_titles -= job.title
 
-/datum/category_item/player_setup_item/occupation/content(mob/user, limit = 19, list/splitJobs = list("Chief Engineer"))  //VOREStation Edit
+/datum/category_item/player_setup_item/occupation/content(mob/user, limit = 20, list/splitJobs = list("Chief Engineer"))  //VOREStation Edit
 	if(!job_master)
 		return
 

--- a/maps/southern_cross/southern_cross_jobs_vr.dm
+++ b/maps/southern_cross/southern_cross_jobs_vr.dm
@@ -1,7 +1,7 @@
-var/const/SAR 				=(1<<11)
-var/const/PILOT 			=(1<<15)
+var/const/PATHFINDER 		=(1<<11)
 var/const/EXPLORER 			=(1<<12)
-var/const/PATHFINDER 		=(1<<13)
+var/const/PILOT 			=(1<<13)
+var/const/SAR 				=(1<<14)
 
 /obj/item/weapon/card/id/medical/sar
 	assignment = "Field Medic"
@@ -43,31 +43,32 @@ var/const/PATHFINDER 		=(1<<13)
 /datum/job/pathfinder
 	title = "Pathfinder"
 	flag = PATHFINDER
-	department = "Science"
+	department = "Exploration"
+	head_position = 1
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the research director"
-	selection_color = "#AD6BAD"
+	selection_color = "#d6d05c"
 	idtype = /obj/item/weapon/card/id/explorer/head/pathfinder
 	economic_modifier = 7
 	minimal_player_age = 7
 
 	access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway)
-	minimal_access = list(access_eva, access_pilot, access_explorer, access_research, access_gateway)
+	minimal_access = list(access_eva, access_maint_tunnels, access_external_airlocks, access_pilot, access_explorer, access_research, access_gateway)
 	outfit_type = /decl/hierarchy/outfit/job/pathfinder
 
 /datum/job/pilot
 	title = "Pilot"
 	flag = PILOT
-	department = "Civilian"
-	department_flag = CIVILIAN
+	department = "Exploration"
+	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the pathfinder and the head of personnel"
-	selection_color = "#515151"
+	selection_color = "#999440"
 	idtype = /obj/item/weapon/card/id/explorer/pilot
 	economic_modifier = 5
 	minimal_player_age = 3
@@ -78,13 +79,13 @@ var/const/PATHFINDER 		=(1<<13)
 /datum/job/explorer
 	title = "Explorer"
 	flag = EXPLORER
-	department = "Science"
+	department = "Exploration"
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the pathfinder and the research director"
-	selection_color = "#633D63"
+	selection_color = "#999440"
 	idtype = /obj/item/weapon/card/id/explorer/explorer
 	economic_modifier = 6
 	access = list(access_explorer, access_research)
@@ -94,13 +95,13 @@ var/const/PATHFINDER 		=(1<<13)
 /datum/job/sar
 	title = "Field Medic"
 	flag = SAR
-	department = "Medical"
+	department = "Exploration"
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the pathfinder and the chief medical officer"
-	selection_color = "#013D3B"
+	selection_color = "#999440"
 	idtype = /obj/item/weapon/card/id/medical/sar
 	economic_modifier = 6
 	minimal_player_age = 3


### PR DESCRIPTION
- Moves explorer job roles from their respective departments into an Exploration sub-department
- CHAIN OF COMMAND WILL REMAIN UNCHANGED
- ACCESS WILL REMAIN UNCHANGED
Note: Pathfinder's minimum access is getting tweaked, in case minimum access ever gets used.

This is a purely clerical change that is being done for two reasons.
1: To enable off duty exploration role, important for the upcoming timeclock PR. The upcoming timeclock functionality will cause difficulties for expedition roles, due to, at present, being in a wide variety of different departments.
2: Generally, explorer roles in other departments tended to create confusion, as people would ask (or even demand) those roles to do station-side duties, even if their access (or lack thereof) made it impossible.